### PR TITLE
Update gem- and ruby version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 /.bundle/
 /.yardoc
-/Gemfile.lock
 /_yardoc/
 /coverage/
 /doc/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,88 @@
+PATH
+  remote: ../powerdns_db_cli
+  specs:
+    powerdns_db_cli (0.0.9)
+      activerecord (~> 7.0, >= 7.0.7.2)
+      terminal-table (~> 3.0, >= 3.0.2)
+      thor (~> 1.2, >= 1.2.2)
+
+PATH
+  remote: .
+  specs:
+    powerdns_dyndns (0.0.2)
+      powerdns_db_cli (~> 0.0.9, >= 0)
+      rack (~> 2.2.4)
+      rack-test (~> 2.1.0)
+      sinatra (~> 3.1.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activemodel (7.0.7.2)
+      activesupport (= 7.0.7.2)
+    activerecord (7.0.7.2)
+      activemodel (= 7.0.7.2)
+      activesupport (= 7.0.7.2)
+    activesupport (7.0.7.2)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+    concurrent-ruby (1.2.2)
+    diff-lcs (1.5.0)
+    i18n (1.14.1)
+      concurrent-ruby (~> 1.0)
+    minitest (5.20.0)
+    mustermann (3.0.0)
+      ruby2_keywords (~> 0.0.1)
+    nio4r (2.5.9)
+    puma (6.3.1)
+      nio4r (~> 2.0)
+    rack (2.2.8)
+    rack-protection (3.1.0)
+      rack (~> 2.2, >= 2.2.4)
+    rack-test (2.1.0)
+      rack (>= 1.3)
+    rake (13.0.6)
+    rspec (3.12.0)
+      rspec-core (~> 3.12.0)
+      rspec-expectations (~> 3.12.0)
+      rspec-mocks (~> 3.12.0)
+    rspec-core (3.12.2)
+      rspec-support (~> 3.12.0)
+    rspec-expectations (3.12.3)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-mocks (3.12.6)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-support (3.12.1)
+    ruby2_keywords (0.0.5)
+    sinatra (3.1.0)
+      mustermann (~> 3.0)
+      rack (~> 2.2, >= 2.2.4)
+      rack-protection (= 3.1.0)
+      tilt (~> 2.0)
+    sqlite3 (1.6.5-x86_64-linux)
+    terminal-table (3.0.2)
+      unicode-display_width (>= 1.1.1, < 3)
+    thor (1.2.2)
+    tilt (2.2.0)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    unicode-display_width (2.4.2)
+
+PLATFORMS
+  x86_64-linux
+
+DEPENDENCIES
+  bundler (~> 2.4.10)
+  powerdns_db_cli!
+  powerdns_dyndns!
+  puma (~> 6.3, >= 6.3.1)
+  rake (~> 13.0.6)
+  rspec (~> 3.12.0)
+  sqlite3 (~> 1.6.4)
+
+BUNDLED WITH
+   2.4.10

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,4 @@
 PATH
-  remote: ../powerdns_db_cli
-  specs:
-    powerdns_db_cli (0.0.9)
-      activerecord (~> 7.0, >= 7.0.7.2)
-      terminal-table (~> 3.0, >= 3.0.2)
-      thor (~> 1.2, >= 1.2.2)
-
-PATH
   remote: .
   specs:
     powerdns_dyndns (0.0.2)
@@ -18,12 +10,12 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (7.0.7.2)
-      activesupport (= 7.0.7.2)
-    activerecord (7.0.7.2)
-      activemodel (= 7.0.7.2)
-      activesupport (= 7.0.7.2)
-    activesupport (7.0.7.2)
+    activemodel (7.0.8)
+      activesupport (= 7.0.8)
+    activerecord (7.0.8)
+      activemodel (= 7.0.8)
+      activesupport (= 7.0.8)
+    activesupport (7.0.8)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -36,7 +28,11 @@ GEM
     mustermann (3.0.0)
       ruby2_keywords (~> 0.0.1)
     nio4r (2.5.9)
-    puma (6.3.1)
+    powerdns_db_cli (0.0.9)
+      activerecord (~> 7.0, >= 7.0.7.2)
+      terminal-table (~> 3.0, >= 3.0.2)
+      thor (~> 1.2, >= 1.2.2)
+    puma (6.4.0)
       nio4r (~> 2.0)
     rack (2.2.8)
     rack-protection (3.1.0)
@@ -63,11 +59,11 @@ GEM
       rack (~> 2.2, >= 2.2.4)
       rack-protection (= 3.1.0)
       tilt (~> 2.0)
-    sqlite3 (1.6.5-x86_64-linux)
+    sqlite3 (1.6.6-x86_64-linux)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     thor (1.2.2)
-    tilt (2.2.0)
+    tilt (2.3.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.4.2)
@@ -77,7 +73,6 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (~> 2.4.10)
-  powerdns_db_cli!
   powerdns_dyndns!
   puma (~> 6.3, >= 6.3.1)
   rake (~> 13.0.6)

--- a/powerdns_dyndns.gemspec
+++ b/powerdns_dyndns.gemspec
@@ -14,13 +14,16 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 1.13'
-  spec.add_development_dependency 'rake', '~> 12.0'
-  spec.add_development_dependency 'rspec', '~> 3.5.0'
-  spec.add_development_dependency 'sqlite3', '~> 1.3.13'
+  spec.add_development_dependency 'bundler', '~> 2.4.10'
+  spec.add_development_dependency 'rake', '~> 13.0.6'
+  spec.add_development_dependency 'rspec', '~> 3.12.0'
+  spec.add_development_dependency 'sqlite3', '~> 1.6.4'
+  spec.add_development_dependency 'puma', '~> 6.3', '>= 6.3.1'
 
-  spec.add_runtime_dependency 'powerdns_db_cli', '>= 0', '~> 0.0.6'
-  spec.add_runtime_dependency 'rack', '~> 1.6.11'
-  spec.add_runtime_dependency 'rack-test', '~> 0.6.3'
-  spec.add_runtime_dependency 'sinatra', '~> 1.4.7'
+  spec.add_runtime_dependency 'powerdns_db_cli', '>= 0', '~> 0.0.9'
+  spec.add_runtime_dependency 'rack', '~> 2.2.4'
+  spec.add_runtime_dependency 'rack-test', '~> 2.1.0'
+  spec.add_runtime_dependency 'sinatra', '~> 3.1.0'
+
+  spec.required_ruby_version = "~> 3.2"
 end


### PR DESCRIPTION
This PR will not work until nning/powerdns_db_cli#1 is merged and updated on ruby gems since it references verion `0.0.9` of the `powerdns_db_cli` gem. Once the gem is updated this PR needs a regenerated `Gemfile.lock` since there is currently a reference to a local development path of the gem.